### PR TITLE
Unity version recommendation, extra setup step

### DIFF
--- a/software/software.md
+++ b/software/software.md
@@ -17,7 +17,8 @@ These assets are dependent on [Release 4.4.0](https://github.com/leapmotion/Unit
 ## Getting Started:
 
 * Make sure your North Star AR Headset is plugged in
-* Create a new Project in Unity 2018.2 or above
+* In windows display settings make sure the headset is showing at the correct resolution (2880x1600) and is to the right of the main monitor.
+* Create a new Project in Unity 2018.4 LTS
 * Import "LeapAR.unitypackage"
 * Navigate to `LeapMotion/North Star/Scenes/NorthStar.unity`
 * Click on the `ARCameraRig` game object and look for the `WindowOffsetManager` component


### PR DESCRIPTION
changed recommendations to unity 2018.4 LTS as there is a bug in 2019.3 occasionally with matrix out of bounds. 

Added line for making sure the display is showing properly in display settings, as that is necessary for the unity code to work properly.